### PR TITLE
Simplify `GenericMetadata` __str__ method

### DIFF
--- a/darkseid/genericmetadata.py
+++ b/darkseid/genericmetadata.py
@@ -108,12 +108,34 @@ class SeriesMetadata(GeneralResource):
     volume: Optional[int] = None
     format: Optional[str] = None
 
+    def __repr__(self) -> str:
+        cls = self.__class__
+        cls_name = cls.__name__
+        indent = " " * 4
+        res = [f"{cls_name}("]
+        for f in fields(cls):
+            value = getattr(self, f.name)
+            res.append(f"{indent}{f.name} = {value!r},")
+        res.append(")")
+        return "\n".join(res)
+
 
 @dataclass
 class CreditMetadata:
     person: str
     role: List[RoleMetadata]
     id_: Optional[int] = None
+
+    def __repr__(self) -> str:
+        cls = self.__class__
+        cls_name = cls.__name__
+        indent = " " * 4
+        res = [f"{cls_name}("]
+        for f in fields(cls):
+            value = getattr(self, f.name)
+            res.append(f"{indent}{f.name} = {value!r},")
+        res.append(")")
+        return "\n".join(res)
 
 
 @dataclass

--- a/darkseid/genericmetadata.py
+++ b/darkseid/genericmetadata.py
@@ -16,8 +16,6 @@ from typing import List, Optional, Tuple, TypedDict
 
 import pycountry
 
-from .utils import list_to_string
-
 MAX_UPC = 17
 MAX_ISBN = 13
 
@@ -108,34 +106,12 @@ class SeriesMetadata(GeneralResource):
     volume: Optional[int] = None
     format: Optional[str] = None
 
-    def __repr__(self) -> str:
-        cls = self.__class__
-        cls_name = cls.__name__
-        indent = " " * 4
-        res = [f"{cls_name}("]
-        for f in fields(cls):
-            value = getattr(self, f.name)
-            res.append(f"{indent}{f.name} = {value!r},")
-        res.append(")")
-        return "\n".join(res)
-
 
 @dataclass
 class CreditMetadata:
     person: str
     role: List[RoleMetadata]
     id_: Optional[int] = None
-
-    def __repr__(self) -> str:
-        cls = self.__class__
-        cls_name = cls.__name__
-        indent = " " * 4
-        res = [f"{cls_name}("]
-        for f in fields(cls):
-            value = getattr(self, f.name)
-            res.append(f"{indent}{f.name} = {value!r},")
-        res.append(")")
-        return "\n".join(res)
 
 
 @dataclass
@@ -163,17 +139,6 @@ class GTIN(Validations):
             raise ValueError(f"ISBN has a length greater than {MAX_ISBN}")
 
         return value
-
-    def __repr__(self) -> str:
-        cls = self.__class__
-        cls_name = cls.__name__
-        indent = " " * 4
-        res = [f"{cls_name}("]
-        for f in fields(cls):
-            value = getattr(self, f.name)
-            res.append(f"{indent}{f.name} = {value!r},")
-        res.append(")")
-        return "\n".join(res)
 
 
 @dataclass
@@ -364,79 +329,13 @@ class GenericMetadata:
             self.credits.append(new_credit)
 
     def __str__(self) -> str:
-        vals: List[Tuple[str, str]] = []
-
-        if self.is_empty:
-            return "No metadata"
-
-        def add_string(tag: str, val: str) -> None:
-            if val is not None and f"{val}" != "":
-                vals.append((tag, val))
-
-        def add_attr_string(tag: str) -> None:
-            add_string(tag, getattr(self, tag))
-
-        add_attr_string("series")
-        add_attr_string("issue")
-        add_attr_string("collection_title")
-        add_attr_string("issue_count")
-        if self.stories:
-            add_attr_string("stories")
-        add_attr_string("publisher")
-        add_attr_string("cover_date")
-        add_attr_string("store_date")
-        if self.prices:
-            add_attr_string("price")
-        add_attr_string("gtin")
-        add_attr_string("volume_count")
-        if self.genres:
-            add_attr_string("genres")
-        add_attr_string("language")
-        add_attr_string("country")
-        add_attr_string("critical_rating")
-        add_attr_string("alternate_series")
-        add_attr_string("alternate_number")
-        add_attr_string("alternate_count")
-        add_attr_string("imprint")
-        add_attr_string("web_link")
-        add_attr_string("manga")
-
-        if self.black_and_white:
-            add_attr_string("black_and_white")
-        add_attr_string("age_rating")
-        if self.story_arcs:
-            add_attr_string("story_arcs")
-        add_attr_string("series_group")
-        add_attr_string("scan_info")
-        if self.characters:
-            add_attr_string("characters")
-        if self.teams:
-            add_attr_string("teams")
-        if self.locations:
-            add_attr_string("locations")
-        if self.reprints:
-            add_attr_string("reprints")
-        add_attr_string("comments")
-        add_attr_string("notes")
-
-        add_string("tags", list_to_string(self.tags))
-
-        for c in self.credits:
-            primary = ""
-            if "primary" in c and c.primary:
-                primary = " [P]"
-            add_string("credit", f"{c.role}: {c.person}{primary}")
-
-        # find the longest field name
-        flen = 0
-        for i in vals:
-            flen = max(flen, len(i[0]))
-        flen += 1
-
-        # format the data nicely
-        outstr = ""
-        fmt_str = "{0: <" + str(flen) + "} {1}\n"
-        for i in vals:
-            outstr += fmt_str.format(f"{i[0]}:", i[1])
-
-        return outstr
+        cls = self.__class__
+        cls_name = cls.__name__
+        indent = " " * 4
+        res = [f"{cls_name}("]
+        for f in fields(cls):
+            value = getattr(self, f.name)
+            if value is not None:
+                res.append(f"{indent}{f.name} = {value!r},")
+        res.append(")")
+        return "\n".join(res)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ CI_XSD = TEST_FILES_PATH / "ComicInfo.xsd"
 RAR_PATH = TEST_FILES_PATH / "Captain Science #001-cix-cbi.cbr"
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def fake_metadata():
     meta_data = GenericMetadata()
     meta_data.series = SeriesMetadata(

--- a/tests/test_darkseid_genericmetadata.py
+++ b/tests/test_darkseid_genericmetadata.py
@@ -3,7 +3,14 @@ from decimal import Decimal
 
 import pytest
 
-from darkseid.genericmetadata import GTIN, CreditMetadata, GenericMetadata, Price, RoleMetadata
+from darkseid.genericmetadata import (
+    GTIN,
+    CreditMetadata,
+    GenericMetadata,
+    Price,
+    RoleMetadata,
+    SeriesMetadata,
+)
 
 MARTY = "Martin Egeland"
 PETER = "Peter David"
@@ -125,3 +132,23 @@ def test_gtin_repr() -> None:
     isbn = None,\n)"""
     gtin = GTIN(75960620237900511)
     assert str(gtin) == expected
+
+
+def test_series_repr() -> None:
+    expected = """SeriesMetadata(
+    name = 'Batman',
+    id_ = 12345,
+    sort_name = 'The Batman',
+    volume = 1,
+    format = 'Annual',\n)"""
+    series = SeriesMetadata("Batman", 12345, "The Batman", 1, "Annual")
+    assert str(series) == expected
+
+
+def test_credit_repr() -> None:
+    expected = """CreditMetadata(
+    person = 'John Byrne',
+    role = [RoleMetadata(name='Artist', id_=1, primary=False)],
+    id_ = 54321,\n)"""
+    md = CreditMetadata("John Byrne", [RoleMetadata("Artist", 1)], 54321)
+    assert str(md) == expected

--- a/tests/test_darkseid_genericmetadata.py
+++ b/tests/test_darkseid_genericmetadata.py
@@ -3,14 +3,7 @@ from decimal import Decimal
 
 import pytest
 
-from darkseid.genericmetadata import (
-    GTIN,
-    CreditMetadata,
-    GenericMetadata,
-    Price,
-    RoleMetadata,
-    SeriesMetadata,
-)
+from darkseid.genericmetadata import GTIN, CreditMetadata, GenericMetadata, Price, RoleMetadata
 
 MARTY = "Martin Egeland"
 PETER = "Peter David"
@@ -19,21 +12,27 @@ PENCILLER = "Penciller"
 COVER = "Cover"
 
 
-# def test_metadata_print_str(fake_metadata):
-#     expect_res = (
-#         "series:          SeriesMetadata(name='Aquaman', sort_name='Aquaman', "
-#         "volume=1, format='Annual', id=None)\n"
-#         "issue:           0\n"
-#         "stories:         ['A Crash of Symbols']\n"
-#         "publisher:       DC Comics\n"
-#         "cover_date:      1994-12-01\n"
-#         "black_and_white: True\n"
-#         "story_arcs:      ['Final Crisis']\n"
-#         "characters:      ['Aquaman', 'Mera', 'Garth']\n"
-#         "teams:           ['Justice League', 'Teen Titans']\n"
-#         "comments:        Just some sample metadata.\n"
-#     )
-#     assert str(fake_metadata) == expect_res
+def test_metadata_print_str(fake_metadata):
+    expect_res = """GenericMetadata(
+    is_empty = False,
+    series = SeriesMetadata(name='Aquaman', id_=None, sort_name='Aquaman', volume=1, format='Annual'),
+    issue = '0',
+    stories = [GeneralResource(name='A Crash of Symbols', id_=None)],
+    publisher = GeneralResource(name='DC Comics', id_=None),
+    cover_date = datetime.date(1994, 12, 1),
+    prices = [],
+    genres = [],
+    comments = 'Just some sample metadata.',
+    black_and_white = True,
+    story_arcs = [GeneralResource(name='Final Crisis', id_=None)],
+    characters = [GeneralResource(name='Aquaman', id_=None), GeneralResource(name='Mera', id_=None), GeneralResource(name='Garth', id_=None)],
+    teams = [GeneralResource(name='Justice League', id_=None), GeneralResource(name='Teen Titans', id_=None)],
+    locations = [],
+    credits = [],
+    reprints = [],
+    tags = [],
+    pages = [],\n)"""  # noqa: #B950
+    assert str(fake_metadata) == expect_res
 
 
 def test_metadata_overlay(
@@ -124,31 +123,3 @@ def test_bad_gtin(upc, isbn, reason) -> None:
 @pytest.mark.parametrize("upc, isbn, expected, reason", good_gtin)
 def test_good_gtin(upc, isbn, expected, reason) -> None:
     assert GTIN(upc, isbn) == expected
-
-
-def test_gtin_repr() -> None:
-    expected = """GTIN(
-    upc = 75960620237900511,
-    isbn = None,\n)"""
-    gtin = GTIN(75960620237900511)
-    assert str(gtin) == expected
-
-
-def test_series_repr() -> None:
-    expected = """SeriesMetadata(
-    name = 'Batman',
-    id_ = 12345,
-    sort_name = 'The Batman',
-    volume = 1,
-    format = 'Annual',\n)"""
-    series = SeriesMetadata("Batman", 12345, "The Batman", 1, "Annual")
-    assert str(series) == expected
-
-
-def test_credit_repr() -> None:
-    expected = """CreditMetadata(
-    person = 'John Byrne',
-    role = [RoleMetadata(name='Artist', id_=1, primary=False)],
-    id_ = 54321,\n)"""
-    md = CreditMetadata("John Byrne", [RoleMetadata("Artist", 1)], 54321)
-    assert str(md) == expected


### PR DESCRIPTION
Make use of the dataclasses fields to format the string output.