### PR TITLE
Skip any bad images in a rarfile

### DIFF
--- a/darkseid/comic.py
+++ b/darkseid/comic.py
@@ -186,7 +186,11 @@ class ZipArchiver(UnknownArchiver):
         try:
             with zipfile.ZipFile(self.path, mode="w", allowZip64=True) as zout:
                 for filename in other_archive.get_filename_list():
-                    data = other_archive.read_file(filename)
+                    try:
+                        data = other_archive.read_file(filename)
+                    except rarfile.BadRarFile:
+                        # Skip any bad images in the file.
+                        continue
                     if data is not None:
                         zout.writestr(filename, data)
             return True


### PR DESCRIPTION
If  a rarfile has a bad file within it, let's skip that file when converting to a zip file.