### PR TITLE
Fix ComicInfo.xml `_get_root` to add attribs

### DIFF
--- a/darkseid/comicinfo.py
+++ b/darkseid/comicinfo.py
@@ -98,14 +98,15 @@ class ComicInfo:
         pattern = r"|".join(delimiters)
         return split(pattern, string)
 
-    def _get_root(self: "ComicInfo", xml: any) -> ET.Element:
-        if xml:
-            root = ET.ElementTree(ET.fromstring(xml)).getroot()  # noqa: S314
-        else:
-            # build a tree structure
-            root = ET.Element("ComicInfo")
-            root.attrib["xmlns:xsi"] = "https://www.w3.org/2001/XMLSchema-instance"
-            root.attrib["xmlns:xsd"] = "https://www.w3.org/2001/XMLSchema"
+    @staticmethod
+    def _get_root(xml: any) -> ET.Element:
+        root = (
+            ET.ElementTree(ET.fromstring(xml)).getroot()  # noqa: S314
+            if xml
+            else ET.Element("ComicInfo")
+        )
+        root.attrib["xmlns:xsi"] = "https://www.w3.org/2001/XMLSchema-instance"
+        root.attrib["xmlns:xsd"] = "https://www.w3.org/2001/XMLSchema"
 
         return root
 

--- a/tests/test_comicinfo.py
+++ b/tests/test_comicinfo.py
@@ -93,6 +93,28 @@ def test_meta_write_to_file(test_meta_data: Metadata, tmp_path: Path) -> None:
     assert validate(tmp_file, CI_XSD) is True
 
 
+def test_meta_write_to_existing_file(test_meta_data: Metadata, tmp_path: Path) -> None:
+    # sourcery skip: extract-duplicate-method
+    """Test of writing the metadata to a file and then modifying comicinfo.xml"""
+    # Write test metadata to file
+    tmp_file = tmp_path / "test-write.xml"
+    ci = ComicInfo()
+    ci.write_to_external_file(tmp_file, test_meta_data)
+    assert tmp_file.read_text() is not None
+    assert validate(tmp_file, CI_XSD) is True
+    # Read the comicinfo.xml file and verify content
+    md = ci.read_from_external_file(tmp_file)
+    assert md.genres == test_meta_data.genres
+    # Modify the metadata and overwrite the existing comicinfo.xml
+    md.genres = []
+    ci.write_to_external_file(tmp_file, md)
+    assert tmp_file.read_text() is not None
+    assert validate(tmp_file, CI_XSD) is True
+    # Now reback the modified comicinfo.xml and verify
+    new_md = ci.read_from_external_file(tmp_file)
+    assert new_md.genres is None
+
+
 def test_invalid_age_write_to_file(tmp_path: Path) -> None:
     """Test writing of invalid age rating value to a file."""
     aquaman = Series("Aquaman")


### PR DESCRIPTION
When rewriting an existing `comicinfo.xml` the root attributes weren't being added.