### PR TITLE
Add support for `Universes` metadata

### DIFF
--- a/darkseid/metadata.py
+++ b/darkseid/metadata.py
@@ -141,6 +141,11 @@ class Basic:
 
 
 @dataclass
+class Universe(Basic):
+    designation: str | None = None
+
+
+@dataclass
 class Role(Basic):
     primary: bool = False
 
@@ -397,6 +402,7 @@ class Metadata:
     characters: list[Basic] = field(default_factory=list)
     teams: list[Basic] = field(default_factory=list)
     locations: list[Basic] = field(default_factory=list)
+    universes: list[Universe] = field(default_factory=list)
 
     credits: list[Credit] = field(default_factory=list)
     reprints: list[Basic] = field(default_factory=list)
@@ -429,7 +435,7 @@ class Metadata:
                 self.is_empty = False
                 break
 
-    def overlay(self: "Metadata", new_md: "Metadata") -> None:
+    def overlay(self: "Metadata", new_md: "Metadata") -> None:  # noqa: PLR0912
         """
         Overlays a metadata object on this one.
 
@@ -501,6 +507,8 @@ class Metadata:
             assign("teams", new_md.teams)
         if len(new_md.locations) > 0:
             assign("locations", new_md.locations)
+        if len(new_md.universes) > 0:
+            assign("universes", new_md.universes)
         if len(new_md.reprints) > 0:
             assign("reprints", new_md.reprints)
         assign("comments", new_md.comments)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from darkseid.comic import Comic
-from darkseid.metadata import Arc, Basic, Metadata, Price, Series
+from darkseid.metadata import Arc, Basic, Metadata, Price, Series, Universe
 
 TEST_FILES_PATH = Path("tests/test_files")
 IMG_DIR = TEST_FILES_PATH / "Captain_Science_001"
@@ -34,6 +34,7 @@ def fake_metadata() -> Metadata:
         Basic("Garth"),
     ]
     md.teams = [Basic("Justice League"), Basic("Infinity, Inc")]
+    md.universes = [Universe(id_=25, name="ABC", designation="Earth 25")]
     md.comments = "Just some sample metadata."
     md.black_and_white = True
     md.is_empty = False

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -28,6 +28,7 @@ def test_metadata_print_str(fake_metadata: Metadata) -> None:
     characters = [Basic(name='Aquaman', id_=None), Basic(name='Mera', id_=None), Basic(name='Garth', id_=None)],
     teams = [Basic(name='Justice League', id_=None), Basic(name='Infinity, Inc', id_=None)],
     locations = [],
+    universes = [Universe(name='ABC', id_=25, designation='Earth 25')],
     credits = [],
     reprints = [],
     tags = [],
@@ -50,6 +51,7 @@ def test_metadata_overlay(fake_metadata: Metadata, fake_overlay_metadata: Metada
     assert md.reprints == fake_overlay_metadata.reprints
     assert md.prices == fake_metadata.prices
     assert md.collection_title == fake_metadata.collection_title
+    assert md.universes == fake_metadata.universes
 
 
 def test_metadata_credits(fake_metadata: Metadata) -> None:


### PR DESCRIPTION
GCD & Metron have `Universes` data and if any future metadata format might want to use it.