### PR TITLE
Update `imprint` metadata type

### DIFF
--- a/darkseid/metadata.py
+++ b/darkseid/metadata.py
@@ -373,6 +373,7 @@ class Metadata:
         collection_title (Optional[str]): The title of the collection.
         stories (list[Basic]): The list of stories.
         publisher (Optional[Basic]): The publisher information.
+        imprint (Optional[Basic]): The imprint information.
         cover_date (Optional[date]): The cover date.
         store_date (Optional[date]): The store date.
         prices (list[Price]): The list of prices.
@@ -386,7 +387,6 @@ class Metadata:
         alternate_series (Optional[str]): The alternate series.
         alternate_number (Optional[str]): The alternate number.
         alternate_count (Optional[int]): The count of alternates.
-        imprint (Optional[str]): The imprint.
         notes (Optional[str]): The notes.
         web_link (Optional[str]): The web link.
         manga (Optional[str]): The manga information.
@@ -433,6 +433,7 @@ class Metadata:
     collection_title: str | None = None
     stories: list[Basic] = field(default_factory=list)
     publisher: Basic | None = None
+    imprint: Basic | None = None
     cover_date: date | None = None
     store_date: date | None = None
     prices: list[Price] = field(default_factory=list)
@@ -448,7 +449,6 @@ class Metadata:
     alternate_series: str | None = None
     alternate_number: str | None = None
     alternate_count: int | None = None
-    imprint: str | None = None
     notes: str | None = None
     web_link: str | None = None
     manga: str | None = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,7 @@ def fake_metadata() -> Metadata:
     md.issue = "0"
     md.stories = [Basic("A Crash of Symbols")]
     md.publisher = Basic("DC Comics")
+    md.imprint = Basic("Vertigo", 9)
     md.cover_date = date(1994, 12, 1)
     md.story_arcs = [Arc("Final Crisis, Inc")]
     md.characters = [

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,6 +19,7 @@ def test_metadata_print_str(fake_metadata: Metadata) -> None:
     issue = '0',
     stories = [Basic(name='A Crash of Symbols', id_=None)],
     publisher = Basic(name='DC Comics', id_=None),
+    imprint = Basic(name='Vertigo', id_=9),
     cover_date = datetime.date(1994, 12, 1),
     prices = [],
     genres = [],
@@ -52,6 +53,8 @@ def test_metadata_overlay(fake_metadata: Metadata, fake_overlay_metadata: Metada
     assert md.prices == fake_metadata.prices
     assert md.collection_title == fake_metadata.collection_title
     assert md.universes == fake_metadata.universes
+    assert md.imprint.name == fake_metadata.imprint.name
+    assert md.imprint.id_ == fake_metadata.imprint.id_
 
 
 def test_metadata_credits(fake_metadata: Metadata) -> None:


### PR DESCRIPTION
Change metadata type to Basic(), so we can track the id_.