### PR TITLE
Update zip.py

### DIFF
--- a/darkseid/archivers/zip.py
+++ b/darkseid/archivers/zip.py
@@ -51,7 +51,10 @@ class ZipArchiver(Archiver):
 
         try:
             with ZipFile(self.path, mode="r") as zf:
-                return zf.read(archive_file)
+                for zipped_file in zf.infolist():
+                    if not zipped_file.is_dir() and  archive_file in zipped_file.filename:
+                        with zf.open(zipped_file.filename, "r") as f:
+                            return f.read()
         except (BadZipfile, OSError) as e:
             logger.exception(
                 "Error reading zip archive %s :: %s",


### PR DESCRIPTION
`read_file` in `zip.py` now checks zipped subdirectories for target file

I was having an issue with metron-tagger where when trying to operate on .cbz files where the ComicInfo wasn't in the top level directory the program would error out. After putting it through the debugger I found the issue was that the ZipFile.read() function would check the full path within the zipfile. So files where the ComicInfo was in a subdirectory within the zip file would throw an error as ZipFile.name property was `{path_name}/ComicInfo.xml` rather than simply `ComicInfo.xml`. 

This change has `read_file` function check if `ComicInfo.xml` is anywhere in the path name rather than only returning exact matches.