### PR TITLE
Bad Permission When Removing Metadata

### DIFF
--- a/darkseid/comic.py
+++ b/darkseid/comic.py
@@ -334,6 +334,8 @@ class Comic:
                 for path in self._archiver.get_filename_list()
                 if Path(path).name.lower() == self._ci_xml_filename.lower()
             ]
+            if not metadata_files:
+                return False
             write_success = self._archiver.remove_files(metadata_files)
             return self._successful_write(write_success, False, None)
         return True


### PR DESCRIPTION
If the comic doesn't have permissions to get the filenames contained within it, return False when calling the remove_metadata() method