### PR TITLE
Add missing MetronInfo age rating

### DIFF
--- a/darkseid/metroninfo.py
+++ b/darkseid/metroninfo.py
@@ -72,13 +72,7 @@ class MetronInfo:
         }
     )
     mix_age_ratings = frozenset(
-        {
-            "unknown",
-            "everyone",
-            "teen",
-            "teen plus",
-            "mature",
-        }
+        {"unknown", "everyone", "teen", "teen plus", "mature", "explicit", "adult"}
     )
     mix_series_format = frozenset(
         {


### PR DESCRIPTION
Forgot to add "Explicit" and "Adult" to the MetronInfo age ratings set