### PR TITLE
Handle Non-Valid ComicInfo cover dates.

### DIFF
--- a/darkseid/comicinfo.py
+++ b/darkseid/comicinfo.py
@@ -122,6 +122,23 @@ class ComicInfo:
         }
     )
 
+    @staticmethod
+    def _set_cover_date(
+        tmp_year: int | None, tmp_month: int | None, tmp_day: int | None
+    ) -> date | None:
+        if tmp_year is None or tmp_month is None:
+            return None
+
+        try:
+            cov_date = (
+                date(tmp_year, tmp_month, 1)
+                if tmp_day is None
+                else date(tmp_year, tmp_month, tmp_day)
+            )
+        except ValueError:
+            return None
+        return cov_date
+
     def metadata_from_string(self: ComicInfo, string: str) -> Metadata:
         """
         Parses an XML string representation into a Metadata object.
@@ -377,11 +394,9 @@ class ComicInfo:
         tmp_year = xlate(get("Year"), True)
         tmp_month = xlate(get("Month"), True)
         tmp_day = xlate(get("Day"), True)
-        if tmp_year is not None and tmp_month is not None:
-            if tmp_day is not None:
-                md.cover_date = date(tmp_year, tmp_month, tmp_day)
-            else:
-                md.cover_date = date(tmp_year, tmp_month, 1)
+        cover_date = self._set_cover_date(tmp_year, tmp_month, tmp_day)
+        if cover_date is not None:
+            md.cover_date = cover_date
         # Publisher info
         pub = xlate(get("Publisher"))
         imprint = xlate(get("Imprint"))

--- a/tests/test_comicinfo.py
+++ b/tests/test_comicinfo.py
@@ -23,6 +23,48 @@ from darkseid.metadata import (
 CI_XSD = Path("tests/test_files/ComicInfo.xsd")
 
 
+@pytest.mark.parametrize(
+    ("tmp_year", "tmp_month", "tmp_day", "expected"),
+    [
+        # Happy path tests
+        (2023, 5, 15, date(2023, 5, 15)),  # Valid full date
+        (2023, 5, None, date(2023, 5, 1)),  # Valid year and month, no day
+        # Edge cases
+        (2023, 2, 28, date(2023, 2, 28)),  # End of February non-leap year
+        (2024, 2, 29, date(2024, 2, 29)),  # Leap year
+        (2023, 1, 1, date(2023, 1, 1)),  # Start of the year
+        (2023, 12, 31, date(2023, 12, 31)),  # End of the year
+        # Error cases
+        (2023, 2, 30, None),  # Invalid day in February
+        (2023, 13, 1, None),  # Invalid month
+        (2023, 0, 1, None),  # Invalid month
+        (2023, 1, 0, None),  # Invalid day
+        (None, 5, 15, None),  # Missing year
+        (2023, None, 15, None),  # Missing month
+    ],
+    ids=[
+        "valid_full_date",
+        "valid_year_month_no_day",
+        "end_of_february_non_leap",
+        "leap_year",
+        "start_of_year",
+        "end_of_year",
+        "invalid_day_february",
+        "invalid_month_13",
+        "invalid_month_0",
+        "invalid_day_0",
+        "missing_year",
+        "missing_month",
+    ],
+)
+def test_set_cover_date(tmp_year, tmp_month, tmp_day, expected):
+    # Act
+    result = ComicInfo()._set_cover_date(tmp_year, tmp_month, tmp_day)  # NOQA: SLF001
+
+    # Assert
+    assert result == expected
+
+
 @pytest.fixture
 def test_credits() -> list[Credit]:
     return [


### PR DESCRIPTION
Don't write the Cover Date to ComicInfo if the date isn't valid