### PR TITLE
Handle KeyError in ZipFile

### DIFF
--- a/darkseid/archivers/zip.py
+++ b/darkseid/archivers/zip.py
@@ -59,6 +59,13 @@ class ZipArchiver(Archiver):
                 archive_file,
             )
             raise OSError from e
+        except KeyError:
+            logger.exception(
+                "File does not exist in zip archive %s :: %s",
+                self.path,
+                archive_file,
+            )
+            raise
 
     def remove_file(self: ZipArchiver, archive_file: str) -> bool:
         """
@@ -130,6 +137,13 @@ class ZipArchiver(Archiver):
         except (BadZipfile, OSError):
             logger.exception(
                 "Error writing zip archive %s :: %s",
+                self.path,
+                fn,
+            )
+            return False
+        except KeyError:
+            logger.exception(
+                "File does not exist in zip archive %s :: %s",
                 self.path,
                 fn,
             )

--- a/tests/test_archiver_zip.py
+++ b/tests/test_archiver_zip.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from zipfile import ZipFile
 
 import pytest
 
@@ -113,3 +114,16 @@ def test_copy_from_archive(zip_archiver, other_archive_files, data):
     for file in other_archive_files:
         assert file in zip_archiver.get_filename_list()
         assert zip_archiver.read_file(file).decode() == content
+
+
+def test_read_file_key_error(tmp_path):
+    # Arrange
+    zip_path = tmp_path / "test.zip"
+    with ZipFile(zip_path, "w") as zf:
+        zf.writestr("existing_file.txt", b"test content")
+
+    archiver = ZipArchiver(zip_path)
+
+    # Act & Assert
+    with pytest.raises(KeyError):
+        archiver.read_file("non_existing_file.txt")


### PR DESCRIPTION
This PR handles a KeyError exception by either returning False or raising the KeyError exception.