### PR TITLE
Remove Archivers `remove_file` method

### DIFF
--- a/darkseid/archivers/archiver.py
+++ b/darkseid/archivers/archiver.py
@@ -335,43 +335,11 @@ class Archiver(ABC):
         """
 
     @abstractmethod
-    def remove_file(self, archive_file: str) -> bool:
-        """Remove a file from the archive.
-
-        Deletes the specified file from the archive. The operation is
-        permanent and cannot be undone. If the file doesn't exist,
-        the behavior depends on the implementation but should not raise
-        an exception.
-
-        Args:
-            archive_file: Path of the file to remove from the archive.
-                Should use forward slashes as path separators.
-
-        Returns:
-            True if the file was successfully removed or didn't exist,
-            False if the removal failed for other reasons.
-
-        Examples:
-            >>> # Remove a single file
-            >>> success = archive.remove_file("old_config.txt")
-            >>> if success:
-            ...     print("File removed successfully")
-            >>> else:
-            ...     print("Failed to remove file")
-
-        Note:
-            This method only removes files, not directories. Empty directories
-            may remain in the archive depending on the format and implementation.
-
-        """
-
-    @abstractmethod
     def remove_files(self, filename_list: list[str]) -> bool:
         """Remove multiple files from the archive.
 
         Batch operation to remove multiple files from the archive in a single
-        call. This is more efficient than calling remove_file() multiple times
-        for large numbers of files.
+        call.
 
         Args:
             filename_list: List of file paths to remove from the archive.

--- a/darkseid/archivers/factory.py
+++ b/darkseid/archivers/factory.py
@@ -116,25 +116,6 @@ class UnknownArchiver(Archiver):
         """
         return False
 
-    def remove_file(self, archive_file: str) -> bool:  # noqa: ARG002
-        """Remove a single file from the archive.
-
-        This method is not implemented for unknown archive types and always returns False.
-
-        Args:
-            archive_file: The filename to remove from the archive.
-
-        Returns:
-            bool: Always False, indicating that file removal is not supported for unknown archive types.
-
-        Examples:
-            >>> archiver = UnknownArchiver(Path("file.unknown"))
-            >>> archiver.remove_file("file_to_remove.txt")
-            False
-
-        """
-        return False
-
     def remove_files(self, filename_list: list[str]) -> bool:  # noqa: ARG002
         """Remove multiple files from the archive.
 

--- a/darkseid/archivers/rar.py
+++ b/darkseid/archivers/rar.py
@@ -12,7 +12,7 @@ Examples:
     >>> print(content.decode('utf-8'))
 
 Note:
-    All write operations (write_file, remove_file, copy_from_archive) will
+    All write operations (write_file, remove_files, copy_from_archive) will
     return False and log warnings since RAR archives are read-only.
 
 """
@@ -148,28 +148,6 @@ class RarArchiver(Archiver):
 
         """
         logger.warning("Cannot write to RAR archive: %s", archive_file)
-        return False
-
-    def remove_file(self, archive_file: str) -> bool:
-        """Attempt to remove a file from the RAR archive.
-
-        Args:
-            archive_file: The path of the file to remove from the archive.
-
-        Returns:
-            False: RAR files are read-only, so this operation always fails.
-
-        Note:
-            This method logs a warning and returns False immediately.
-            No actual removal operation is attempted since RAR format
-            does not support modification of existing archives.
-
-        Warning:
-            A warning will be logged indicating that the remove operation
-            was attempted on a read-only RAR archive.
-
-        """
-        logger.warning("Cannot remove file from RAR archive: %s", archive_file)
         return False
 
     def remove_files(self, filename_list: list[str]) -> bool:

--- a/darkseid/archivers/sevenzip.py
+++ b/darkseid/archivers/sevenzip.py
@@ -509,6 +509,11 @@ class SevenZipArchiver(Archiver):
             current_files = self.get_filename_list()
             files_to_remove = set(filename_list)
 
+            # If none of the files to remove are in the archive, return True
+            current_files_set = set(current_files)
+            if not any(filename in current_files_set for filename in filename_list):
+                return True
+
             # Read all files except those to remove
             remaining_files: dict[str, bytes] = {}
 

--- a/darkseid/archivers/sevenzip.py
+++ b/darkseid/archivers/sevenzip.py
@@ -473,76 +473,10 @@ class SevenZipArchiver(Archiver):
         else:
             return True
 
-    def remove_file(self, archive_file: str) -> bool:
-        """Remove a file from the 7z archive.
-
-        Removes the specified file from the archive. The archive is completely
-        reconstructed without the removed file. If the file doesn't exist,
-        the operation is considered successful.
-
-        Args:
-            archive_file: Path of the file to remove from the archive.
-
-        Returns:
-            True if the file was successfully removed or didn't exist,
-                False if the operation failed.
-
-        Examples:
-            >>> with SevenZipArchiver(Path("archive.cb7")) as archive:
-            ...     # Remove a single file
-            ...     success = archive.remove_file("temp.txt")
-            ...     if success:
-            ...         print("File removed successfully")
-            ...
-            ...     # Remove file from subdirectory
-            ...     archive.remove_file("old_data/obsolete.json")
-
-        Performance:
-            This operation rewrites the entire archive, so it can be slow for
-            large archives. Use remove_files() for removing multiple files.
-
-        Note:
-            No exception is raised if the file doesn't exist - the method
-            returns True in this case.
-
-        """
-        try:
-            if not self._path.exists():
-                return True  # File doesn't exist, so removal is successful
-
-            # Get current file list
-            current_files = self.get_filename_list()
-
-            if archive_file not in current_files:
-                return True  # File doesn't exist, so removal is successful
-
-            # Read all files except the one to remove
-            remaining_files: dict[str, bytes] = {}
-
-            for filename in current_files:
-                if filename != archive_file:
-                    remaining_files[filename] = self.read_file(filename)
-
-            # Rewrite archive without the removed file
-            with self._get_archive_for_writing() as write_archive:
-                for filename, content in remaining_files.items():
-                    write_archive.writestr(content, filename)
-
-            # Update cache
-            self._file_cache.pop(archive_file, None)
-            self._filename_list_cache = None  # Invalidate filename cache
-        except Exception as e:
-            self._handle_error("remove", archive_file, e)
-            return False
-        else:
-            return True
-
     def remove_files(self, filename_list: list[str]) -> bool:
         """Remove multiple files from the 7z archive.
 
         Removes all specified files from the archive in a single operation.
-        This is more efficient than calling remove_file() multiple times
-        because it only reconstructs the archive once.
 
         Args:
             filename_list: List of file paths to remove from the archive.
@@ -561,10 +495,6 @@ class SevenZipArchiver(Archiver):
             ...         print("All files removed successfully")
             ...     else:
             ...         print("Some files could not be removed")
-
-        Performance:
-            This is much more efficient than multiple remove_file() calls
-            because it only reconstructs the archive once.
 
         Note:
             The operation is atomic - either all files are removed or none are.

--- a/darkseid/archivers/tar.py
+++ b/darkseid/archivers/tar.py
@@ -243,48 +243,6 @@ class TarArchiver(Archiver):
         else:
             return True
 
-    def remove_file(self, archive_file: str) -> bool:
-        """Remove a file from the TAR archive.
-
-        Args:
-            archive_file: Path of the file to remove from the archive.
-
-        Returns:
-            True if the file was successfully removed, False if the removal failed or didn't exist
-
-        """
-        try:
-            if not self._path.exists():
-                return True  # File doesn't exist, consider it removed
-
-            # Read all files except the one to remove
-            remaining_files = {}
-            file_exists = False
-            with self._open_for_reading() as tar:
-                for member in tar.getmembers():
-                    if member.isfile():
-                        if member.name == archive_file:
-                            file_exists = True
-                        else:
-                            file_obj = tar.extractfile(member)
-                            if file_obj:
-                                remaining_files[member.name] = file_obj.read()
-
-            if not file_exists:
-                return False
-
-            # Recreate archive without the removed file
-            with self._open_for_writing() as tar:
-                for filename, file_data in remaining_files.items():
-                    tarinfo = tarfile.TarInfo(name=filename)
-                    tarinfo.size = len(file_data)
-                    tar.addfile(tarinfo, io.BytesIO(file_data))
-        except (tarfile.TarError, OSError) as e:
-            self._handle_error("remove", archive_file, e)
-            return False
-        else:
-            return True
-
     def remove_files(self, filename_list: list[str]) -> bool:
         """Remove multiple files from the TAR archive.
 

--- a/tests/test_archivers.py
+++ b/tests/test_archivers.py
@@ -277,7 +277,7 @@ def test_remove_file_success(temp_dir, archive_type, archiver_class, filename, r
     assert "file1.txt" in archiver.get_filename_list()
 
     # Remove file
-    result = archiver.remove_file("file1.txt")
+    result = archiver.remove_files(["file1.txt"])
     assert result is True
 
     # Verify file is gone
@@ -300,8 +300,8 @@ def test_remove_nonexistent_file(temp_dir, archive_type, archiver_class, filenam
         archive_path = request.getfixturevalue("sample_tar_path")
 
     archiver = archiver_class(archive_path)
-    result = archiver.remove_file("nonexistent.txt")
-    assert result is False
+    result = archiver.remove_files(["nonexistent.txt"])
+    assert result is True
 
 
 @pytest.mark.parametrize(("archive_type", "archiver_class", "filename"), READ_WRITE_ARCHIVE_DATA)
@@ -579,7 +579,7 @@ def test_rar_readonly_operations(sample_rar_path, operation):
     if operation == "write_file":
         result = archiver.write_file("test.txt", "data")
     elif operation == "remove_file":
-        result = archiver.remove_file("test.txt")
+        result = archiver.remove_files(["test.txt"])
     elif operation == "remove_files":
         result = archiver.remove_files(["file1.txt", "file2.txt"])
     elif operation == "copy_from_archive":
@@ -619,7 +619,6 @@ def test_rar_get_filename_list_error(mock_rar_file, sample_rar_path):
     [
         ("name", [], "Unknown"),
         ("write_file", ["test.txt", "data"], False),
-        ("remove_file", ["test.txt"], False),
         ("remove_files", [["file1.txt", "file2.txt"]], False),
         ("get_filename_list", [], []),
         ("copy_from_archive", [Mock()], False),
@@ -671,9 +670,6 @@ def test_factory_register_new_archiver(temp_dir):
             return b"mock"
 
         def write_file(self, archive_file: str, data) -> bool:
-            return True
-
-        def remove_file(self, archive_file: str) -> bool:
             return True
 
         def remove_files(self, filename_list: list[str]) -> bool:


### PR DESCRIPTION
This PR removes the Archivers `remove_file` method. The `remove_files` method should be used.